### PR TITLE
[#38]모집글 탈퇴회원의 셀이 없어지는 오류 수정

### DIFF
--- a/TrackUs-iOS/TrackUs-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TrackUs-iOS/TrackUs-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "3c0196a0861bedd6a846bc0509c3076f248bb8b4daf8cdcdc79e5ecc5fb9fda8",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -24,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "3b62f154d00019ae29a71e9738800bb6f18b236d",
-        "version" : "10.19.2"
+        "revision" : "076b241a625e25eac22f8849be256dfb960fcdfe",
+        "version" : "10.19.1"
       }
     },
     {
@@ -33,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "03189348b7798fe94b892a35883f1dc745814fe0",
-        "version" : "10.28.0"
+        "revision" : "8bcaf973b1d84e119b7c7c119abad72ed460979f",
+        "version" : "10.27.0"
       }
     },
     {
@@ -42,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "fe727587518729046fc1465625b9afd80b5ab361",
-        "version" : "10.28.0"
+        "revision" : "70df02431e216bed98dd461e0c4665889245ba70",
+        "version" : "10.27.0"
       }
     },
     {
@@ -96,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk",
       "state" : {
-        "revision" : "e9e649d3ba823c3673867d3d09010fc77005a940",
-        "version" : "2.22.3"
+        "revision" : "9f9b830dfd7ee66607c6fddcfeb1a6bc07e48714",
+        "version" : "2.22.2"
       }
     },
     {
@@ -137,5 +136,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/TrackUs-iOS/TrackUs-iOS.xcodeproj/xcshareddata/xcschemes/TrackUs-iOS.xcscheme
+++ b/TrackUs-iOS/TrackUs-iOS.xcodeproj/xcshareddata/xcschemes/TrackUs-iOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1540"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/TrackUs-iOS/TrackUs-iOS/Common/Service/PostService.swift
+++ b/TrackUs-iOS/TrackUs-iOS/Common/Service/PostService.swift
@@ -444,4 +444,30 @@ class PostService {
             }
         }
     }
+    
+    // 사용자 내보내기
+    func kickUser(postUid: String, userUid: String, completion: @escaping ([String]?, Error?) -> Void) {
+        Firestore.firestore().collection("posts").document(postUid).getDocument { snapshot, error in
+            guard let document = try? snapshot?.data(as: Post.self), error == nil else {
+                completion(nil, error)
+                return
+            }
+            
+            var updateMembers = document.members
+            
+            if let index = updateMembers.firstIndex(of: userUid) {
+                updateMembers.remove(at: index)
+            } else {
+                return
+            }
+            
+            Firestore.firestore().collection("posts").document(postUid).updateData(["members": updateMembers]) { updateError in
+                if let updateError = updateError {
+                    completion(nil, updateError)
+                } else {
+                    completion(updateMembers, nil)
+                }
+            }
+        }
+    }
 }

--- a/TrackUs-iOS/TrackUs-iOS/Common/Service/PostService.swift
+++ b/TrackUs-iOS/TrackUs-iOS/Common/Service/PostService.swift
@@ -316,6 +316,12 @@ class PostService {
     // 모집글 참여인원의 프로필이미지와 이름 가져오기
     func fetchMembers(uid: String, completion: @escaping (String?, String?) -> Void) {
         Firestore.firestore().collection("users").document(uid).getDocument { snapshot, error in
+            
+            if let error = error {
+                completion(nil, nil)
+                return
+            }
+            
             guard let data = snapshot?.data() else { return }
             let name = data["name"] as? String ?? ""
             let imageUrl = data["profileImageUrl"] as? String ?? ""

--- a/TrackUs-iOS/TrackUs-iOS/Presentation/Mate/Controllers/CourseDetailVC.swift
+++ b/TrackUs-iOS/TrackUs-iOS/Presentation/Mate/Controllers/CourseDetailVC.swift
@@ -621,6 +621,11 @@ class CourseDetailVC: UIViewController {
     private func LongPressCollectionCell(_ user: Int) {
         let action = UIAlertAction(title: "내보내기", style: .destructive) { action in
             
+            if self.members[user] == self.uid {
+                self.showAlert(title: "오류", message: "방장은 내보낼 수 없습니다.", action: "제한")
+                return
+            }
+            
             PostService().kickUser(postUid: self.postUid, userUid: self.members[user]) { updateMembers, error in
                 if error != nil {
                     // 에러 alert

--- a/TrackUs-iOS/TrackUs-iOS/Presentation/Mate/Controllers/CourseDetailVC.swift
+++ b/TrackUs-iOS/TrackUs-iOS/Presentation/Mate/Controllers/CourseDetailVC.swift
@@ -414,7 +414,6 @@ class CourseDetailVC: UIViewController {
         let p = gestureRecognizer.location(in: collectionView)
         
         if let indexPath = collectionView.indexPathForItem(at: p) {
-            print(indexPath.row)
             LongPressCollectionCell(indexPath.row)
         }
     }

--- a/TrackUs-iOS/TrackUs-iOS/Presentation/Mate/Controllers/CourseDetailVC.swift
+++ b/TrackUs-iOS/TrackUs-iOS/Presentation/Mate/Controllers/CourseDetailVC.swift
@@ -36,6 +36,8 @@ class CourseDetailVC: UIViewController {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .white
         collectionView.register(MatePeopleListCell.self, forCellWithReuseIdentifier: MatePeopleListCell.identifier)
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.showsVerticalScrollIndicator = false
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
     }()
@@ -794,6 +796,13 @@ extension CourseDetailVC: UICollectionViewDelegate, UICollectionViewDataSource, 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         
         return UIEdgeInsets(top: 0, left: 10, bottom: 20, right: 10)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        guard let cell = collectionView.cellForItem(at: indexPath) as? MatePeopleListCell else {
+            return true
+        }
+        return !cell.isUnknown
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {


### PR DESCRIPTION
### 연관된 이슈 🚨

### 고민한 점
- 탈퇴회원 처리
- 방장인 경우 LongPressGesture로 사용자 내보내기

### 해결 과정(필요시 스크린샷 첨부)

- 탈퇴회원 처리

```swift
func configure(uid: String, isOwner: Bool) {
        currentUID = uid
        
        profileImageView.image = UIImage(systemName: "person.crop.circle.fill")?.withRenderingMode(.alwaysTemplate)
        profileImageView.layer.borderWidth = 4
        nameLabel.text = "탈퇴회원"
        nameLabel.textColor = .gray2
        ownerCrownView.isHidden = true
        overlayView.isHidden = true
        xmarkView.isHidden = true
        
        isUnknown = true
        
        PostService().fetchMembers(uid: uid) { [weak self] name, url in
            guard let self = self, self.currentUID == uid else { return }
            guard let name = name, let url = url else {
                // 데이터가 없는 경우 기본 설정 유지
                self.ownerCrownView.isHidden = !isOwner
                return
            }
            
            DispatchQueue.main.async {
                if url.isEmpty {
                    self.profileImageView.image = UIImage(systemName: "person.crop.circle.fill")?.withRenderingMode(.alwaysTemplate)
                    self.profileImageView.layer.borderWidth = 4
                } else {
                    self.profileImageView.loadImage(url: url)
                    self.profileImageView.layer.borderWidth = 1
                }
                
                if name.isEmpty {
                    self.nameLabel.text = "탈퇴회원"
                } else {
                    // 이름이 7글자 이상이면 줄임표 표시
                    self.nameLabel.text = name.count > 7 ? "\(name.prefix(6)).." : name
                }
                
                self.nameLabel.textColor = (User.currentUid == uid) ? .black : .gray2
                self.ownerCrownView.isHidden = !isOwner
                
                // 차단한 사용자인지 확인
                self.overlayView.isHidden = !UserManager.shared.user.blockList.contains(uid)
                self.xmarkView.isHidden = self.overlayView.isHidden
                
                self.isUnknown = false
            }
        }
    }
```
프로필 이미지와 이름을 기본 이미지와 "탈퇴회원" 으로 초기화를 해준뒤

탈퇴한 회원인 경우
fetchMembers함수에서 오류가 발생하기 때문에
만약 오류가 발생하면

초기화상태 그대로 사용

에러가 발생하지 않으면

사용자의 이미지와 이름으로 바꿔주도록 하였다.

+ 추가로 발생한 문제

컬렉션뷰에서 셀 재사용으로 인해
프로필이미지가 기본이미지인 사용자와 탈퇴회원의 셀 부분에 다른 사용자의 이미지와 이름으로 바뀌어버리는 오류가 발생했다.

오류를 수정하기 위해

```swift
override func prepareForReuse() {
        super.prepareForReuse()
        
        profileImageView.image = nil
        nameLabel.text = nil
        ownerCrownView.isHidden = true
        overlayView.isHidden = true
        xmarkView.isHidden = true
        currentUID = nil
    }
```

prepareForReuse()를 사용하여
데이터 로드가 되기 전 컬렉션뷰를 초기화를 해주는 작업을 해주었다.

- 방장인 경우 LongPressGesture 로 내보내기 기능 추가

컬렉션뷰에서는 기본적으로 didSelectItemAt 이라는 함수가 있는데
이 함수는 셀을 클릭 했을 경우 작업이 되는 함수인데

문제는 LongPress를 지원하지 않아서 따로 추가를 해줘야 했다.

```swift
private func setupLongGestureRecognizerOnCollection() {
        let longPressedGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(gestureRecognizer:)))
        longPressedGesture.minimumPressDuration = 0.5
        longPressedGesture.delegate = self
        longPressedGesture.delaysTouchesBegan = true
        collectionView.addGestureRecognizer(longPressedGesture)
    }
```
컬렉션 뷰의 셀에 UILongPressGestureRecognizer를 추가해 주고

```swift
@objc func handleLongPress(gestureRecognizer: UILongPressGestureRecognizer) {
        if (gestureRecognizer.state != .began) {
            return
        }
        
        let isOwner = ownerUid == uid
        
        guard isOwner else { return }
        
        let p = gestureRecognizer.location(in: collectionView)
        
        if let indexPath = collectionView.indexPathForItem(at: p) {
            LongPressCollectionCell(indexPath.row)
        }
    }

private func LongPressCollectionCell(_ user: Int) {
        let action = UIAlertAction(title: "내보내기", style: .destructive) { action in
            
            PostService().kickUser(postUid: self.postUid, userUid: self.members[user]) { updateMembers, error in
                if error != nil {
                    // 에러 alert
                    self.showAlert(title: "오류", message: "오류가 발생했습니다.", action: "제한")
                } else {
                    self.members = updateMembers ?? self.members
                }
            }
        }
        
        let cancel = UIAlertAction(title: "취소", style: .cancel)
        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
        
        alert.addAction(action)
        alert.addAction(cancel)
        
        self.present(alert, animated: true)
    }
```
컬렉션뷰에서 방장인 경우에 액션 alert를 띄워서 해당 셀의 uid를 post.members에서 제거하는 코드를 추가해주었다.

